### PR TITLE
Nerf nuclear option

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -280,7 +280,7 @@
   - type: Sprite
     sprite: Objects/Weapons/Grenades/nukenade.rsi
   - type: OnUseTimerTrigger
-    delay: 5
+    delay: 15
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
@@ -299,7 +299,9 @@
   - type: Appearance
   - type: TimerTriggerVisuals
     primingSound:
-      path: /Audio/Effects/countdown.ogg
+      path: /Audio/Announcements/war.ogg
+      params:
+        volume: 50
 
 - type: entity
   name: modular grenade


### PR DESCRIPTION
they kinda like, blew shit up a lot


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Simyon
- tweak: 1984'd nuclear options. They now have a more distinct sound and will go off in 20 seconds instead of 3.
