### PR TITLE
Fix round end not setting the game state to post round

### DIFF
--- a/Content.Server/_SSS/SuspicionGameRule/SuspicionRuleSystem.Rules.cs
+++ b/Content.Server/_SSS/SuspicionGameRule/SuspicionRuleSystem.Rules.cs
@@ -77,6 +77,7 @@ public sealed partial class SuspicionRuleSystem
             if (allInnocents.Count == 0 && allDetectives.Count == 0)
             {
                 _chatManager.DispatchServerAnnouncement("The traitors have won the round.");
+                sus.GameState = SuspicionGameState.PostRound;
                 _roundEndSystem.EndRound(TimeSpan.FromSeconds(sus.PostRoundDuration));
                 return;
             }
@@ -84,6 +85,7 @@ public sealed partial class SuspicionRuleSystem
             if (allTraitors.Count == 0)
             {
                 _chatManager.DispatchServerAnnouncement("The innocents have won the round.");
+                sus.GameState = SuspicionGameState.PostRound;
                 _roundEndSystem.EndRound(TimeSpan.FromSeconds(sus.PostRoundDuration));
                 return;
             }


### PR DESCRIPTION
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Simyon
- fix: Round will not end properly. No more "The X have won the round" after the round has already ended.
