### PR TITLE
Traitor Item: Dehydrated Carp Box

### DIFF
--- a/Resources/Locale/en-US/_SSS/store_items.ftl
+++ b/Resources/Locale/en-US/_SSS/store_items.ftl
@@ -1,0 +1,2 @@
+uplink-carp-box-name = Dehydrated Carp Box
+uplink-carp-box-desc = Box filled with 4 dehydrated carps. Make sure your friends pet it as well!

--- a/Resources/Prototypes/_SSS/Catalog/categories.yml
+++ b/Resources/Prototypes/_SSS/Catalog/categories.yml
@@ -24,6 +24,11 @@
   name: store-category-disruption
   priority: 5
 
+- type: storeCategory
+  id: SSSTraitorAllies
+  name: store-category-allies
+  priority: 6
+
 ### SSS Detective
 - type: storeCategory
   id: SSSDetectiveWeapons

--- a/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
+++ b/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
@@ -364,6 +364,16 @@
   categories:
   - SSSTraitorWearables
 
+- type: listing
+  id: UplinkCarpBoxSSS
+  name: uplink-carp-box-name
+  description: uplink-carp-box-desc
+  productEntity: BoxDehydratedCarp
+  cost:
+    Telecrystal: 3
+  categories:
+  - SSSTraitorAllies
+
 # DETECTIVE WEAPONS
 
 - type: listing

--- a/Resources/Prototypes/_SSS/Objects/implants.yml
+++ b/Resources/Prototypes/_SSS/Objects/implants.yml
@@ -29,6 +29,7 @@
     - SSSTraitorWearables
     - SSSTraitorChemicals
     - SSSTraitorDisruption
+    - SSSTraitorAllies
 
 - type: entity
   parent: UplinkImplant

--- a/Resources/Prototypes/_SSS/Objects/store_items.yml
+++ b/Resources/Prototypes/_SSS/Objects/store_items.yml
@@ -1,0 +1,33 @@
+- type: entity
+  parent: BoxCardboard
+  id: BoxDehydratedCarp
+  name: dehydrated carp box
+  description: uplink-carp-box-desc
+  suffix: Traitor
+  components:
+  - type: StorageFill
+    contents:
+    - id: DehydratedSpaceCarp
+    - id: DehydratedSpaceCarp
+    - id: DehydratedSpaceCarp
+    - id: DehydratedSpaceCarp
+    - id: WaterChemistryBottle
+  - type: Sprite
+    layers:
+    - state: internals
+    - state: emergencytank
+
+- type: entity
+  id: WaterChemistryBottle
+  suffix: water
+  parent: BaseChemistryBottleFilled
+  components:
+  - type: Label
+    currentLabel: reagent-name-water
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: Water
+          Quantity: 30

--- a/Resources/Prototypes/_SSS/Objects/store_items.yml
+++ b/Resources/Prototypes/_SSS/Objects/store_items.yml
@@ -14,8 +14,7 @@
     - id: WaterChemistryBottle
   - type: Sprite
     layers:
-    - state: internals
-    - state: emergencytank
+    - state: box_of_doom
 
 - type: entity
   id: WaterChemistryBottle


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added carp box traitor item

## Why / Balance
Fishy teehee.

4 Carps would be quite devestating usually, but in a game mode where EVERYONE is packing. A grenade could probably do so much more damage if done right than 4 carps. I am leaning to either 2TC or 3TC. Keeping it at 3TC for now unless player feedback says otherwise. 

## Technical details
added new store_items.yml in prototypes for all new SSS items, also added a locale named store_items.ftl. If there is anything I have missed let me know regarding locales. 

## Media
![image](https://github.com/user-attachments/assets/98e71216-82f3-44ac-bb86-c06849eaa745)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- add: Added Dehydrated Carp Box with 4 carps for 3TC. Fish!
