### PR TITLE
Traitor/Detective Item + Changes: Upgradable Armour and Cheaper Wearable TC Cost

### DIFF
--- a/Resources/Locale/en-US/_SSS/store_items.ftl
+++ b/Resources/Locale/en-US/_SSS/store_items.ftl
@@ -1,2 +1,5 @@
 uplink-carp-box-name = Dehydrated Carp Box
 uplink-carp-box-desc = Box filled with 4 dehydrated carps. Make sure your friends pet it as well!
+
+uplink-armour-upgrade-name = Armour Upgrade Kit
+uplink-armour-upgrade-desc = An armour upgrade kit. Use on your armour to upgrade the protection. Armour will drop if equipped!

--- a/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
+++ b/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
@@ -362,6 +362,9 @@
     Telecrystal: 3
   categories:
   - SSSTraitorWearables
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
 
 - type: listing
   id: UplinkClothingOuterHardsuitJuggernautSSS
@@ -408,3 +411,6 @@
     Telecrystal: 2
   categories:
   - SSSDetectiveWearables
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1

--- a/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
+++ b/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
@@ -328,7 +328,7 @@
   description: uplink-clothing-no-slips-shoes-desc
   productEntity: ClothingShoesChameleonNoSlips
   cost:
-    Telecrystal: 4
+    Telecrystal: 2
   categories:
   - SSSTraitorWearables
 
@@ -338,7 +338,7 @@
   description: uplink-clothing-shoes-boots-mag-syndie-desc
   productEntity: ClothingShoesBootsMagSyndie
   cost:
-    Telecrystal: 4
+    Telecrystal: 1
   categories:
   - SSSTraitorWearables
 
@@ -349,7 +349,17 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndicate.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateHardsuitBundle
   cost:
-    Telecrystal: 8
+    Telecrystal: 3
+  categories:
+  - SSSTraitorWearables
+
+- type: listing
+  id: UplinkArmourUpgradeKitSSS
+  name: uplink-armour-upgrade-name
+  description: uplink-armour-upgrade-desc
+  productEntity: ClothingOuterVestWebMercSuspicionUpgradeKit
+  cost:
+    Telecrystal: 3
   categories:
   - SSSTraitorWearables
 
@@ -388,3 +398,13 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
+
+- type: listing
+  id: UplinkArmourUpgradeKitSSSDetective
+  name: uplink-armour-upgrade-name
+  description: uplink-armour-upgrade-desc
+  productEntity: ClothingOuterVestWebMercSuspicionUpgradeKit
+  cost:
+    Telecrystal: 2
+  categories:
+  - SSSDetectiveWearables

--- a/Resources/Prototypes/_SSS/Objects/store_items.yml
+++ b/Resources/Prototypes/_SSS/Objects/store_items.yml
@@ -30,3 +30,18 @@
         reagents:
         - ReagentId: Water
           Quantity: 30
+
+- type: entity
+  name: Armour Upgrade Kit
+  parent: [BaseItem, BaseSyndicateContraband]
+  id: ClothingOuterVestWebMercSuspicionUpgradeKit
+  description: An armour upgrade kit. Use on your armour to upgrade the protection. Armour will drop if equipped!
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: abductor_mod # temp - new item might be better but for now this will work
+  - type: Item
+    size: Small
+  - type: Tag
+    tags:
+    - ClothingOuterVestWebMercSuspicionUpgradeKit

--- a/Resources/Prototypes/_SSS/Objects/suspicion_clothing.yml
+++ b/Resources/Prototypes/_SSS/Objects/suspicion_clothing.yml
@@ -33,6 +33,38 @@
 - type: entity
   parent: ClothingOuterVestWebMerc
   id: ClothingOuterVestWebMercSuspicion
+  suffix: SSS
+  components:
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9 # 30% to 10% resistance, Blunt and Slash are underused damage types, increased viability for Melee
+        Slash: 0.9
+        Piercing: 0.7 # 50% to 30% resistance, giving a path for upgradable armour. Fine tune this value as it could be 20% instead.
+        Heat: 0.9
+  - type: ExplosionResistance
+    damageCoefficient: 0.9 # Leaving this incase we want to modify it.
+  - type: Construction
+    graph: UpgradeClothingOuterVestWebMercSuspicion
+    node: start
+
+- type: entity
+  parent: ClothingOuterVestWebMercSuspicion
+  id: ClothingOuterVestWebMercSuspicionUpgraded
+  suffix: SSS-Upgraded
+  components:
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.5 # 30% back to 50%, weaker to the base game bulletproofvest
+        Heat: 0.9
+  - type: ExplosionResistance
+    damageCoefficient: 0.8 # 10% to 20%, equivilent to the base game bulletproofvest
+  - type: Construction
+    graph: UpgradeClothingOuterVestWebMercSuspicion
+    node: upgraded
 
 - type: entity
   parent: HoPIDCard

--- a/Resources/Prototypes/_SSS/Recipes/Construction/Graphs/Clothing/suspicion_clothing.yml
+++ b/Resources/Prototypes/_SSS/Recipes/Construction/Graphs/Clothing/suspicion_clothing.yml
@@ -1,0 +1,13 @@
+- type: constructionGraph
+  id: UpgradeClothingOuterVestWebMercSuspicion
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: upgraded
+          steps:
+            - tag: ClothingOuterVestWebMercSuspicionUpgradeKit
+              doAfter: 4
+
+    - node: upgraded
+      entity: ClothingOuterVestWebMercSuspicionUpgraded

--- a/Resources/Prototypes/_SSS/tags.yml
+++ b/Resources/Prototypes/_SSS/tags.yml
@@ -1,0 +1,2 @@
+- type: Tag
+  id: ClothingOuterVestWebMercSuspicionUpgradeKit


### PR DESCRIPTION
## About the PR
Added a new Upgrade Kit that can be used on armour for 4 seconds to upgrade it.
Base Armour Vest has been reduced from 50% to 20%, Blunt/Slash is down from 30% to 10%.
Upgraded Armour Vest has been kept at 50% with slightly increased explosion.
Wearable Traitor Items have been mostly decreased including Magboots, No Slips and Hard Suit.

## Why / Balance
Gives the Detective and Traitor a chance to upgrade their armour. This takes either most TC for traitors, and all points for Detectives at round start. 
Armour damage values were balanced around the fact that using something like a shotgun point blank gave too much time for someone to react taking 4 full blasts. This makes no sense as Traitors thrive on catching people off guard. Gun fights were going on for too long (and as much as I like that...), this should make all gun fights alot more intense and quicker. 
MagBoots and Noslips were blatantly underused and not worth. MagBoots are an obvious, slow but cheap version of no slips. Possible removal of MagBoots but I want to keep them to see how things fair.

## Technical details
Used the construction component like for CHIMP handcannons to upgrade them. Added both versions for Detective and Traitors as separate sections in sss_uplink.yml. 

Changed Telecrystal Values in sss_uplink.yml

## Media
![image](https://github.com/user-attachments/assets/b62230e4-4169-4750-bb73-4126934df2e6)

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- add: Armour Upgrade Kit for Detectives (2TC) and Terrorists (3TC)
- tweak: Starting Armour Vest is now 20% Pierce and 10% Blunt/Slash
- tweak: Syndicate Hardsuit Price is now 3TC from 8TC
- tweak: No Slips is now 2TC from 4TC
- tweak: Syndicate MagBoots is now 1TC from 4TC
