### PR TITLE
Fixed: Description for Dehydrated Carps

### DIFF
--- a/Resources/Locale/en-US/_SSS/store_items.ftl
+++ b/Resources/Locale/en-US/_SSS/store_items.ftl
@@ -1,2 +1,2 @@
 uplink-carp-box-name = Dehydrated Carp Box
-uplink-carp-box-desc = Box filled with 4 dehydrated carps. Make sure your friends pet it as well!
+uplink-carp-box-desc = Box filled with 4 dehydrated carps. Make sure your friends pet them as well!

--- a/Resources/Prototypes/_SSS/Objects/store_items.yml
+++ b/Resources/Prototypes/_SSS/Objects/store_items.yml
@@ -2,7 +2,7 @@
   parent: BoxCardboard
   id: BoxDehydratedCarp
   name: dehydrated carp box
-  description: uplink-carp-box-desc
+  description: Box filled with 4 dehydrated carps. Make sure your friends pet them as well!
   suffix: Traitor
   components:
   - type: StorageFill


### PR DESCRIPTION
## About the PR
Locales don't work on entity descriptions, fixed some wording as well

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Dehydrated Carp Description is functional now
