### PR TITLE
Traitor/Detective Item + Changes: Grenades

### DIFF
--- a/Resources/Locale/en-US/_SSS/store_items.ftl
+++ b/Resources/Locale/en-US/_SSS/store_items.ftl
@@ -1,2 +1,5 @@
 uplink-carp-box-name = Dehydrated Carp Box
 uplink-carp-box-desc = Box filled with 4 dehydrated carps. Make sure your friends pet it as well!
+
+uplink-disruptive-throwable-name = Disruptive Grenade Kit
+uplink-disruptive-throwable-desc = A set of 1 flash, smoke and stinger grenades. Perfect for slowing down and getting away.

--- a/Resources/Locale/en-US/_SSS/store_items.ftl
+++ b/Resources/Locale/en-US/_SSS/store_items.ftl
@@ -3,3 +3,5 @@ uplink-carp-box-desc = Box filled with 4 dehydrated carps. Make sure your friend
 
 uplink-disruptive-throwable-name = Disruptive Grenade Kit
 uplink-disruptive-throwable-desc = A set of 1 flash, smoke and stinger grenades. Perfect for slowing down and getting away.
+
+uplink-exploding-syndicate-bomb-SSS-desc = A big, anchored bomb that can create a huge explosion if not defused in time. Useful as a distraction. Has an adjustable timer with a minimum setting of 90 seconds. Stays quiet for 30 seconds upon activation.

--- a/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
+++ b/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
@@ -378,3 +378,13 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
+
+- type: listing
+  id: UplinkBoxDisruptiveThrowableSSSDetective
+  name: uplink-disruptive-throwable-name
+  description: uplink-disruptive-throwable-desc
+  productEntity: BoxDisruptiveThrowable
+  categories:
+  - SSSDetectiveExplosives
+  cost:
+    Telecrystal: 1

--- a/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
+++ b/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
@@ -159,7 +159,7 @@
   id: UplinkSyndicateBombSSS
   restockTime: 120
   name: uplink-exploding-syndicate-bomb-name
-  description: uplink-exploding-syndicate-bomb-desc
+  description: uplink-exploding-syndicate-bomb-SSS-desc
   productEntity: SyndicateBombSSS
   categories:
   - SSSTraitorExplosives

--- a/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
+++ b/Resources/Prototypes/_SSS/Catalog/sss_uplink.yml
@@ -92,23 +92,13 @@
   categories:
   - SSSTraitorExplosives
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
 
 - type: listing
-  id: UplinkExplosiveGrenadeFlashSSS
-  name: uplink-flash-grenade-name
-  description: uplink-flash-grenade-desc
-  productEntity: GrenadeFlashBang
-  categories:
-  - SSSTraitorExplosives
-  cost:
-    Telecrystal: 1
-
-- type: listing
-  id: UplinkSmokeGrenadeSSS
-  name: uplink-smoke-grenade-name
-  description: uplink-smoke-grenade-desc
-  productEntity: SmokeGrenade
+  id: UplinkBoxDisruptiveThrowableSSS
+  name: uplink-disruptive-throwable-name
+  description: uplink-disruptive-throwable-desc
+  productEntity: BoxDisruptiveThrowable
   categories:
   - SSSTraitorExplosives
   cost:
@@ -122,7 +112,7 @@
   categories:
   - SSSTraitorExplosives
   cost:
-    Telecrystal: 5
+    Telecrystal: 3
 
 - type: listing
   id: UplinkSupermatterGrenadeSSS
@@ -132,7 +122,7 @@
   categories:
   - SSSTraitorExplosives
   cost:
-    Telecrystal: 5
+    Telecrystal: 3
 
 - type: listing
   id: UplinkWhiteholeGrenadeSSS
@@ -170,11 +160,11 @@
   restockTime: 120
   name: uplink-exploding-syndicate-bomb-name
   description: uplink-exploding-syndicate-bomb-desc
-  productEntity: SyndicateBomb
+  productEntity: SyndicateBombSSS
   categories:
   - SSSTraitorExplosives
   cost:
-    Telecrystal: 10
+    Telecrystal: 5
 
 - type: listing
   id: UplinkClusterGrenadeSSS
@@ -182,7 +172,7 @@
   description: uplink-cluster-grenade-desc
   productEntity: ClusterGrenade
   cost:
-    Telecrystal: 8
+    Telecrystal: 5
   categories:
   - SSSTraitorExplosives
 

--- a/Resources/Prototypes/_SSS/Objects/store_items.yml
+++ b/Resources/Prototypes/_SSS/Objects/store_items.yml
@@ -30,3 +30,32 @@
         reagents:
         - ReagentId: Water
           Quantity: 30
+
+- type: entity
+  parent: BoxCardboard
+  id: BoxDisruptiveThrowable
+  name: disruptive grenade kit
+  description: A set of 1 flash, smoke and stinger grenades. Perfect for slowing down and getting away.
+  suffix: Traitor
+  components:
+  - type: StorageFill
+    contents:
+    - id: GrenadeFlashBang
+    - id: SmokeGrenade
+    - id: GrenadeStinger
+  - type: Sprite
+    layers:
+    - state: box_of_doom
+
+- type: entity
+  parent: SyndicateBomb
+  id: SyndicateBombSSS
+  suffix: Traitor
+  name: syndicate bomb
+  description: A bomb for Syndicate operatives and agents alike. The real deal, no more training, get to it!
+  components:
+  - type: OnUseTimerTrigger
+    delay: 90
+    delayOptions: [90, 180]
+    initialBeepDelay: 30 # Gives the bomb some more stealth options due to how loud the timer is.
+    beepSound: /Audio/Machines/timer.ogg

--- a/Resources/Prototypes/_SSS/suspicion_spawners.yml
+++ b/Resources/Prototypes/_SSS/suspicion_spawners.yml
@@ -145,7 +145,7 @@
       weight: 90
       children:
       - !type:GroupSelector
-        weight: 85 # Common 
+        weight: 85 # Common
         children:
         - id: ClothingEyesGlassesSunglasses
         - id: ClothingMaskGas
@@ -165,20 +165,20 @@
         - id: Ointment5
         - id: PipeBomb
         - id: FireBomb
-        - id: ExGrenade
+        # - id: ExGrenade # Removing the explosive grenade from rotation, most other throwables seem alright.
         # Toolboxes
         - !type:GroupSelector
           children:
           - id: ToolboxEmergencyFilled
           - id: ToolboxElectricalFilled
           - id: ToolboxMechanicalFilled
-        - id: ToolboxEmergencyFilled # we're not just doubling down on crowbar spawns, we're TRIPLING DOWN on them
+          - id: ToolboxEmergencyFilled # we're not just doubling down on crowbar spawns, we're TRIPLING DOWN on them
       - !type:GroupSelector
         weight: 10 # Rare
         children:
         - id: ClothingEyesHudMedical
         - id: MedkitFilled
-        - id: GrenadeShrapnel
+        # - id: GrenadeShrapnel # Removing the Shrapnel grenade from rotation.
         - id: GrenadeStinger
         - id: CombatMedipen
         - id: ToolboxSyndicateFilled


### PR DESCRIPTION
## About the PR
Added a Grenade Box for Traitors and Detectives
Removed Explosive Grenades and Shrapnel Grenades from Spawning normally
Tweaked Grenade/Explosive TC counts
Reduced the Timer on the Syndicate Bomb to 90 seconds, also giving it a 30 second quiet period. (May be subject to change by giving more access to tools to disarm it)

## Why / Balance
Grenades gave good traitors ways to wipe terrorists out really effective if done right. This to me was quite fun however, innocents were able to hold onto grenades and mearly suicide bomb traitors making a 1:1 trade. On TTT, most grenades were either fire, or push back not explosive. 

The nuclear option still remains spawnable (not purchasable yet). I find this highly funny for the time being.

## Technical details
Created new prototype of a box filled with three items in store_items.yml. Gave it to the Traitor and Detective in sss_uplink.yml

Changed Telecrystal Values in sss_uplink.yml

## Media
![Screenshot_20241022_012954](https://github.com/user-attachments/assets/db2bc316-5add-49bd-b7d8-13d4da53d1f9)

![image](https://github.com/user-attachments/assets/0f5e3a42-7a74-416d-914e-ca944387088e)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- add: Disruptive Grenade Kit for 1TC replacing individual purchases of grenades
- tweak: Syndicate Bomb has a 90 second timer and 30 second quiet period
- tweak: Overall decreased TC cost of Explosives for Traitors
- remove: Explosive and Shrapnel Grenades from spawning naturally