### PR TITLE
Make "the nuclear option" trigger the timer on damage instead of instantly exploding

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -293,9 +293,7 @@
         !type:DamageTrigger
         damage: 50
       behaviors:
-      - !type:TriggerBehavior
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
+      - !type:TimerStartBehavior
   - type: Appearance
   - type: TimerTriggerVisuals
     primingSound:


### PR DESCRIPTION
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Simyon
- tweak: The nuclear option will now trigger the timer instead of instantly exploding upon taking too much damage.
