### PR TITLE
1984 forceguns

### DIFF
--- a/Resources/Prototypes/_SSS/suspicion_spawners.yml
+++ b/Resources/Prototypes/_SSS/suspicion_spawners.yml
@@ -99,8 +99,6 @@
         - id: Chainsaw
         - id: Stunbaton # Not as unfair as you'd think it is, almost everything in this tier is better than it.
         - id: WeaponTeslaGun
-        - id: WeaponTetherGunAdmin
-        - id: WeaponForceGunAdmin
         - id: WeaponMinigun
         - id: WeaponLaserCannon
         - id: WeaponXrayCannon


### PR DESCRIPTION
removes force guns from the loot pool

sus

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Simyon
- remove: Removed forceguns from the lootpool.
