### PR TITLE
centcomm sss beacon update

### DIFF
--- a/Resources/Locale/en-US/_SSS/station-beacons.ftl
+++ b/Resources/Locale/en-US/_SSS/station-beacons.ftl
@@ -1,0 +1,12 @@
+station-beacon-deathsquad-armory = Deathsquad Armory
+station-beacon-ert-armory = ERT Armory
+station-beacon-commander = Commander's Quarters
+station-beacon-commander-vault = Commander's Vault
+station-beacon-surveillance-area = Central Surveillance Area
+station-beacon-ert-room = ERT Meeting Room
+station-beacon-ert-dock = ERT Docking Area
+station-beacon-arrivals-security-checkpoint = Arrivals Security Checkpoint
+station-beacon-arivals-waiting-area = Arrivals Waiting Area
+station-beacon-civilian-area-checkpoint = Civilian Area Checkpoint
+station-beacon-civilian-dock = Civilian Docking Area
+station-beacon-fuel-room = Fuel Rooom

--- a/Resources/Maps/_SSS/centcomm-sss.yml
+++ b/Resources/Maps/_SSS/centcomm-sss.yml
@@ -3663,292 +3663,457 @@ entities:
     - type: Transform
       pos: -3.5,5.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 856
     components:
     - type: Transform
       pos: 20.5,6.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 905
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,-7.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 963
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 23.5,-10.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 977
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 978
     components:
     - type: Transform
       pos: 12.5,7.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 979
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 1088
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 1201
     components:
     - type: Transform
       pos: 12.5,-10.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 1235
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 1341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-9.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 1674
     components:
     - type: Transform
       pos: -14.5,18.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 1675
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,17.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 1676
     components:
     - type: Transform
       pos: -8.5,13.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 1677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,19.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 1955
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 2013
     components:
     - type: Transform
       pos: -1.5,22.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 2562
     components:
     - type: Transform
       pos: 7.5,16.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 2563
     components:
     - type: Transform
       pos: 17.5,17.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 2564
     components:
     - type: Transform
       pos: 24.5,14.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 2565
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 35.5,19.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 2566
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,21.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 2944
     components:
     - type: Transform
       pos: 9.5,26.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 2945
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,18.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 2946
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,30.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 3463
     components:
     - type: Transform
       pos: -22.5,7.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 3464
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 3465
     components:
     - type: Transform
       pos: -22.5,13.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 3466
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,6.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 3986
     components:
     - type: Transform
       pos: -31.5,2.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 3987
     components:
     - type: Transform
       pos: -31.5,7.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 3988
     components:
     - type: Transform
       pos: -21.5,-2.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 3989
     components:
     - type: Transform
       pos: -13.5,-2.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 3990
     components:
     - type: Transform
       pos: -17.5,1.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 4361
     components:
     - type: Transform
       pos: 34.5,-9.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 4475
     components:
     - type: Transform
       pos: -2.5,-24.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 4476
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-24.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 4477
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-24.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 4478
     components:
     - type: Transform
       pos: -9.5,-17.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 4479
     components:
     - type: Transform
       pos: 8.5,-17.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 4480
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-20.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 4977
     components:
     - type: Transform
       pos: 20.5,-12.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 4992
     components:
     - type: Transform
       pos: 18.5,-19.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 5133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,-23.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 5146
     components:
     - type: Transform
       pos: 29.5,-19.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 5257
     components:
     - type: Transform
       pos: 30.5,-14.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 5321
     components:
     - type: Transform
       pos: 32.5,-27.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 5423
     components:
     - type: Transform
       pos: 16.5,-28.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 5934
     components:
     - type: Transform
       pos: -16.5,-30.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 6004
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,-22.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 6103
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-28.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 6180
     components:
     - type: Transform
       pos: 7.5,-30.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 6181
     components:
     - type: Transform
       pos: -8.5,-30.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 6277
     components:
     - type: Transform
       pos: -2.5,-34.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
   - uid: 6397
     components:
     - type: Transform
       pos: -2.5,-40.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 50000
+      autoRecharge: True
 - proto: Ash
   entities:
   - uid: 3828
@@ -18710,6 +18875,229 @@ entities:
     - type: Transform
       pos: 11.5,-4.5
       parent: 1668
+- proto: DefaultStationBeaconArmoryDeathsquad
+  entities:
+  - uid: 7014
+    components:
+    - type: Transform
+      pos: 9.5,31.5
+      parent: 1668
+- proto: DefaultStationBeaconArmoryERT
+  entities:
+  - uid: 7463
+    components:
+    - type: Transform
+      pos: -0.5,-42.5
+      parent: 1668
+- proto: DefaultStationBeaconArrivals
+  entities:
+  - uid: 7457
+    components:
+    - type: Transform
+      pos: 26.5,-0.5
+      parent: 1668
+- proto: DefaultStationBeaconArrivalsSecurityCheckpoint
+  entities:
+  - uid: 7459
+    components:
+    - type: Transform
+      pos: 26.5,-9.5
+      parent: 1668
+    - type: NavMapBeacon
+      color: '#FFFF00FF'
+- proto: DefaultStationBeaconArrivalsWaitingArea
+  entities:
+  - uid: 7458
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 1668
+    - type: NavMapBeacon
+      color: '#FFFF00FF'
+- proto: DefaultStationBeaconAtmospherics
+  entities:
+  - uid: 7449
+    components:
+    - type: Transform
+      pos: 22.5,-28.5
+      parent: 1668
+- proto: DefaultStationBeaconBar
+  entities:
+  - uid: 7451
+    components:
+    - type: Transform
+      pos: 8.5,-23.5
+      parent: 1668
+- proto: DefaultStationBeaconBrig
+  entities:
+  - uid: 7455
+    components:
+    - type: Transform
+      pos: 12.5,24.5
+      parent: 1668
+- proto: DefaultStationBeaconCargo
+  entities:
+  - uid: 7467
+    components:
+    - type: Transform
+      pos: -7.5,15.5
+      parent: 1668
+- proto: DefaultStationBeaconCargoBay
+  entities:
+  - uid: 7456
+    components:
+    - type: Transform
+      pos: -8.5,21.5
+      parent: 1668
+- proto: DefaultStationBeaconCargoReception
+  entities:
+  - uid: 7447
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1668
+- proto: DefaultStationBeaconCentcommCivilianCheckpoint
+  entities:
+  - uid: 7461
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 1668
+    - type: NavMapBeacon
+      color: '#FFFF00FF'
+  - uid: 7462
+    components:
+    - type: Transform
+      pos: -18.5,-26.5
+      parent: 1668
+    - type: NavMapBeacon
+      color: '#FFFF00FF'
+- proto: DefaultStationBeaconCentcommSurveillance
+  entities:
+  - uid: 7460
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1668
+- proto: DefaultStationBeaconChemistry
+  entities:
+  - uid: 7448
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 1668
+- proto: DefaultStationBeaconCommander
+  entities:
+  - uid: 7465
+    components:
+    - type: Transform
+      pos: -19.5,6.5
+      parent: 1668
+- proto: DefaultStationBeaconCommanderVault
+  entities:
+  - uid: 7464
+    components:
+    - type: Transform
+      pos: -11.5,5.5
+      parent: 1668
+- proto: DefaultStationBeaconCourtroom
+  entities:
+  - uid: 7176
+    components:
+    - type: Transform
+      pos: 28.5,17.5
+      parent: 1668
+- proto: DefaultStationBeaconDisposals
+  entities:
+  - uid: 7139
+    components:
+    - type: Transform
+      pos: -16.5,-31.5
+      parent: 1668
+- proto: DefaultStationBeaconEngineering
+  entities:
+  - uid: 7452
+    components:
+    - type: Transform
+      pos: 27.5,-17.5
+      parent: 1668
+- proto: DefaultStationBeaconERTDocking
+  entities:
+  - uid: 7466
+    components:
+    - type: Transform
+      pos: -30.5,0.5
+      parent: 1668
+- proto: DefaultStationBeaconERTMeetingRoom
+  entities:
+  - uid: 7195
+    components:
+    - type: Transform
+      pos: -18.5,-4.5
+      parent: 1668
+- proto: DefaultStationBeaconFuelRoom
+  entities:
+  - uid: 7468
+    components:
+    - type: Transform
+      pos: 31.5,-29.5
+      parent: 1668
+- proto: DefaultStationBeaconGravGen
+  entities:
+  - uid: 7469
+    components:
+    - type: Transform
+      pos: 33.5,-13.5
+      parent: 1668
+- proto: DefaultStationBeaconKitchen
+  entities:
+  - uid: 7135
+    components:
+    - type: Transform
+      pos: -9.5,-23.5
+      parent: 1668
+- proto: DefaultStationBeaconLawOffice
+  entities:
+  - uid: 7454
+    components:
+    - type: Transform
+      pos: 19.5,22.5
+      parent: 1668
+- proto: DefaultStationBeaconLibrary
+  entities:
+  - uid: 7453
+    components:
+    - type: Transform
+      pos: 18.5,16.5
+      parent: 1668
+- proto: DefaultStationBeaconMedbay
+  entities:
+  - uid: 7131
+    components:
+    - type: Transform
+      pos: 14.5,-5.5
+      parent: 1668
+- proto: DefaultStationBeaconMedical
+  entities:
+  - uid: 7450
+    components:
+    - type: Transform
+      pos: 12.5,-12.5
+      parent: 1668
+- proto: DefaultStationBeaconSecurity
+  entities:
+  - uid: 7129
+    components:
+    - type: Transform
+      pos: 12.5,14.5
+      parent: 1668
+- proto: DefaultStationBeaconWardensOffice
+  entities:
+  - uid: 7130
+    components:
+    - type: Transform
+      pos: 9.5,19.5
+      parent: 1668
 - proto: DefibrillatorCabinetFilled
   entities:
   - uid: 2914
@@ -24482,16 +24870,6 @@ entities:
       parent: 1668
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 644
-    components:
-    - type: Transform
-      pos: 31.5,-13.5
-      parent: 1668
-  - uid: 649
-    components:
-    - type: Transform
-      pos: 30.5,-13.5
-      parent: 1668
   - uid: 5176
     components:
     - type: Transform
@@ -31867,21 +32245,33 @@ entities:
     - type: Transform
       pos: 27.5,-30.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 8000000
+      autoRecharge: True
   - uid: 5078
     components:
     - type: Transform
       pos: 22.5,-17.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 8000000
+      autoRecharge: True
   - uid: 5079
     components:
     - type: Transform
       pos: 22.5,-15.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 8000000
+      autoRecharge: True
   - uid: 5080
     components:
     - type: Transform
       pos: 22.5,-16.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 8000000
+      autoRecharge: True
 - proto: SmokingPipeFilledTobacco
   entities:
   - uid: 3753
@@ -32171,11 +32561,6 @@ entities:
     - type: Transform
       pos: 2.5,-25.5
       parent: 1668
-  - uid: 6981
-    components:
-    - type: Transform
-      pos: -11.5,30.5
-      parent: 1668
   - uid: 6983
     components:
     - type: Transform
@@ -32190,11 +32575,6 @@ entities:
     components:
     - type: Transform
       pos: -3.5,11.5
-      parent: 1668
-  - uid: 7014
-    components:
-    - type: Transform
-      pos: -10.5,30.5
       parent: 1668
   - uid: 7017
     components:
@@ -32286,40 +32666,15 @@ entities:
     - type: Transform
       pos: 13.5,10.5
       parent: 1668
-  - uid: 7129
-    components:
-    - type: Transform
-      pos: -33.5,3.5
-      parent: 1668
-  - uid: 7130
-    components:
-    - type: Transform
-      pos: -29.5,-2.5
-      parent: 1668
-  - uid: 7131
-    components:
-    - type: Transform
-      pos: -32.5,3.5
-      parent: 1668
   - uid: 7134
     components:
     - type: Transform
       pos: -20.5,-4.5
       parent: 1668
-  - uid: 7135
-    components:
-    - type: Transform
-      pos: -31.5,-0.5
-      parent: 1668
   - uid: 7138
     components:
     - type: Transform
       pos: -18.5,-6.5
-      parent: 1668
-  - uid: 7139
-    components:
-    - type: Transform
-      pos: -33.5,6.5
       parent: 1668
   - uid: 7142
     components:
@@ -32335,16 +32690,6 @@ entities:
     components:
     - type: Transform
       pos: 12.5,10.5
-      parent: 1668
-  - uid: 7176
-    components:
-    - type: Transform
-      pos: -5.5,10.5
-      parent: 1668
-  - uid: 7195
-    components:
-    - type: Transform
-      pos: 9.5,17.5
       parent: 1668
   - uid: 7198
     components:
@@ -33887,6 +34232,11 @@ entities:
     - type: Transform
       pos: 2.5,-22.5
       parent: 1668
+  - uid: 649
+    components:
+    - type: Transform
+      pos: 32.5,8.5
+      parent: 1668
   - uid: 821
     components:
     - type: Transform
@@ -34141,6 +34491,11 @@ entities:
     components:
     - type: Transform
       pos: -33.5,4.5
+      parent: 1668
+  - uid: 6981
+    components:
+    - type: Transform
+      pos: 22.5,8.5
       parent: 1668
   - uid: 6985
     components:
@@ -34719,6 +35074,11 @@ entities:
       parent: 1668
 - proto: SssSpawnerWeapons
   entities:
+  - uid: 644
+    components:
+    - type: Transform
+      pos: 4.5,19.5
+      parent: 1668
   - uid: 912
     components:
     - type: Transform
@@ -34768,6 +35128,11 @@ entities:
     components:
     - type: Transform
       pos: -7.5,-16.5
+      parent: 1668
+  - uid: 2446
+    components:
+    - type: Transform
+      pos: 30.5,7.5
       parent: 1668
   - uid: 2746
     components:
@@ -35407,61 +35772,86 @@ entities:
       parent: 1668
 - proto: SubstationBasic
   entities:
-  - uid: 617
-    components:
-    - type: Transform
-      pos: 30.5,-12.5
-      parent: 1668
   - uid: 1130
     components:
     - type: Transform
       pos: 15.5,-13.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 2500000
+      autoRecharge: True
   - uid: 1802
     components:
     - type: Transform
       pos: -3.5,20.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 2500000
+      autoRecharge: True
   - uid: 1803
     components:
     - type: Transform
       pos: 2.5,20.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 2500000
+      autoRecharge: True
   - uid: 2199
     components:
     - type: Transform
       pos: 27.5,-31.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 2500000
+      autoRecharge: True
   - uid: 2521
     components:
     - type: Transform
       pos: 15.5,19.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 2500000
+      autoRecharge: True
   - uid: 3432
     components:
     - type: Transform
       pos: -15.5,6.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 2500000
+      autoRecharge: True
   - uid: 3949
     components:
     - type: Transform
       pos: -27.5,6.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 2500000
+      autoRecharge: True
   - uid: 4815
     components:
     - type: Transform
       pos: 17.5,-17.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 2500000
+      autoRecharge: True
   - uid: 4816
     components:
     - type: Transform
       pos: 15.5,-17.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 2500000
+      autoRecharge: True
   - uid: 5958
     components:
     - type: Transform
       pos: -16.5,-29.5
       parent: 1668
+    - type: BatterySelfRecharger
+      autoRechargeRate: 2500000
+      autoRecharge: True
 - proto: SuitStorageBase
   entities:
   - uid: 3902
@@ -39031,6 +39421,11 @@ entities:
     - type: Transform
       pos: 33.5,0.5
       parent: 1668
+  - uid: 617
+    components:
+    - type: Transform
+      pos: 32.5,-14.5
+      parent: 1668
   - uid: 658
     components:
     - type: Transform
@@ -40233,11 +40628,6 @@ entities:
     components:
     - type: Transform
       pos: 35.5,-28.5
-      parent: 1668
-  - uid: 2446
-    components:
-    - type: Transform
-      pos: 32.5,-14.5
       parent: 1668
   - uid: 2501
     components:

--- a/Resources/Prototypes/_SSS/Objects/station-beacons.yml
+++ b/Resources/Prototypes/_SSS/Objects/station-beacons.yml
@@ -1,0 +1,103 @@
+- type: entity
+  parent: DefaultStationBeaconSecurity
+  id: DefaultStationBeaconArmoryDeathsquad
+  suffix: Deathsquad Armory
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-deathsquad-armory
+
+- type: entity
+  parent: DefaultStationBeaconSecurity
+  id: DefaultStationBeaconArmoryERT
+  suffix: ERT Armory
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-ert-armory
+
+- type: entity
+  parent: DefaultStationBeaconCommand
+  id: DefaultStationBeaconCommander
+  suffix: Centcomm Commander's Room
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-commander
+
+- type: entity
+  parent: DefaultStationBeaconCommand
+  id: DefaultStationBeaconCommanderVault
+  suffix: Centcomm Commander's Vault
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-commander-vault
+
+- type: entity
+  parent: DefaultStationBeaconCommand
+  id: DefaultStationBeaconCentcommSurveillance
+  suffix: Centcomm Surveillance Area
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-surveillance-area
+
+- type: entity
+  parent: DefaultStationBeaconCommand
+  id: DefaultStationBeaconERTMeetingRoom
+  suffix: Centcomm ERT Room
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-ert-meeting-room
+
+- type: entity
+  parent: DefaultStationBeaconCommand
+  id: DefaultStationBeaconERTDocking
+  suffix: Centcomm ERT Dock
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-ert-dock
+
+- type: entity
+  parent: DefaultStationBeaconService
+  id: DefaultStationBeaconCentcommCivilianCheckpoint
+  suffix: Centcomm Civilian Checkpoint
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-civilian-area-checkpoint
+
+- type: entity
+  parent: DefaultStationBeaconService
+  id: DefaultStationBeaconCentcommCivilianDocking
+  suffix: Centcomm Civilian Dock
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-civilian-dock
+
+- type: entity
+  parent: DefaultStationBeaconSecurity
+  id: DefaultStationBeaconArrivalsSecurityCheckpoint
+  suffix: Arrivals Security Checkpoint
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-arrivals-security-checkpoint
+
+- type: entity
+  parent: DefaultStationBeacon
+  id: DefaultStationBeaconArrivalsWaitingArea
+  suffix: Arrivals Waiting Area
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-arivals-waiting-area
+
+- type: entity
+  parent: DefaultStationBeaconSupply
+  id: DefaultStationBeaconCargo
+  suffix: Cargo
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-cargo
+
+- type: entity
+  parent: DefaultStationBeaconEngineering
+  id: DefaultStationBeaconFuelRoom
+  suffix: Fuel Room
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-fuel-room


### PR DESCRIPTION
## About the PR
Adds station map beacons to centcomm.
Removes the generators in gravgen and gives the grid infinite power.
Removed some player spawnpoints & added a few random item spawns to make certain areas have meatier loot.

this pr is untested in actual gameplay, but the map initializes fine.

## Why / Balance
map beacons good
power was basically intended to be infinite anyways but it just used debug generators for some reason
player spawns are intended to compact people more. hopefully it has Some Effect but we will see.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Added station beacons to Centcomm.
